### PR TITLE
Bug fixes integration_#1

### DIFF
--- a/build/src/common/libMac5gRange/libMac5gRange.h
+++ b/build/src/common/libMac5gRange/libMac5gRange.h
@@ -126,8 +126,9 @@ typedef struct{
  * @brief Struct for UESubframeRx.Start, as defined in L1-L2_InterfaceDefinition.xlsx
  */
 typedef struct{
-    float snr[132];     //Signal to Noise Ratio per Resource Block //#TODO: define range
-    float ssm;          //SSM: Spectrum Sensing Measurement. Array of 4 bits
+    vector<float> snr;  //Signal to Noise Ratio per Resource Block //#TODO: define range
+    uint8_t ssm;        //SSM: Spectrum Sensing Measurement. Array of 4 bits
+    uint8_t numberPDUs; //Number of PDUs received
     
     /**
      * @brief Serialization method for the struct
@@ -138,16 +139,16 @@ typedef struct{
      **/
     void serialize(vector<uint8_t> & bytes)
     {
-        push_bytes(bytes,(ssm));
-        for(int i=0;i<132;i++)
-            push_bytes(bytes, snr[i]);
+        push_bytes(bytes,ssm);
+        push_bytes(bytes, numberPDUs);
+        serialize_vector(bytes, snr);
     }
 
     /** deserializatyion method for the struct (inverse order)**/
     void deserialize(vector<uint8_t> & bytes)
     {
-        for(int i=131;i>=0;i--)
-            pop_bytes(snr[i], bytes);
+        deserialize_vector(snr, bytes);
+        pop_bytes(numberPDUs, bytes);
         pop_bytes(ssm, bytes);
     }
 }UESubframeRx_Start;
@@ -156,10 +157,11 @@ typedef struct{
  * @brief Struct for RxMetrics, as defined in L1-L2_InterfaceDefinition.xlsx
  */
 typedef struct{
-    float snr[132];         //Channel Signal to Noise Ratio per Resource Block
+    vector<float> snr;      //Channel Signal to Noise Ratio per Resource Block
     float snr_avg;          //Average Signal to Noise Ratio
-    float rankIndicator;    //Rank Indicator
-    float ssReport;         //SS Report: Spectrum Sensing Report, part of RxMetrics. Array of 4 bits
+    uint8_t rankIndicator;  //Rank Indicator
+    uint8_t ssReport;       //SS Report: Spectrum Sensing Report, part of RxMetrics. Array of 4 bits
+    uint8_t numberRBs;      //Allocation previously used on downlink
     
     /**
      * @brief Serialization method for the struct
@@ -172,6 +174,7 @@ typedef struct{
     {
         push_bytes(bytes, snr_avg);
         push_bytes(bytes, rankIndicator);
+        push_bytes(bytes, numberRBs);
     }
 
     /**
@@ -183,14 +186,14 @@ typedef struct{
      **/
     void snr_ssr_serialize(vector<uint8_t> & bytes)
     {
-        for(int i=0;i<132;i++)
-            push_bytes(bytes, snr[i]);
+        serialize_vector(bytes, snr);
         push_bytes(bytes, ssReport);
     }
 
     /** Deserialization method for the struct (inverse order)**/
     void snr_avg_ri_deserialize(vector<uint8_t> & bytes)
     {
+        pop_bytes(numberRBs, bytes);
         pop_bytes(rankIndicator, bytes);
         pop_bytes(snr_avg, bytes);
     }
@@ -199,8 +202,7 @@ typedef struct{
     void snr_ssr_deserialize(vector<uint8_t> & bytes)
     {
         pop_bytes(ssReport, bytes);
-        for(int i=131;i>=0;i--)
-            pop_bytes(snr[i], bytes);
+        deserialize_vector(snr, bytes);
     }
 }RxMetrics;
 
@@ -243,11 +245,11 @@ typedef struct{
         
         //Open Control message queues
         mqControlToPhy = mq_open( MQ_CONTROL_TO_L1, \
-                                O_CREAT|O_RDWR|O_NONBLOCK, \
+                                O_CREAT|O_RDWR, \
                                 0666, \
                                 &messageQueueAttributes);
         mqControlFromPhy = mq_open( MQ_CONTROL_FROM_L1, \
-                                O_CREAT|O_RDWR|O_NONBLOCK, \
+                                O_CREAT|O_RDWR, \
                                 0666, \
                                 &messageQueueAttributes);   
         //Check for errors

--- a/build/src/coreL1/StubPHYLayer.h
+++ b/build/src/coreL1/StubPHYLayer.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDED_CORE_L1_H
 #define INCLUDED_CORE_L1_H
 
+#define CONTROL_TIMEOUT_uSEC 4600 
+
 #include <iostream>     //cout
 #include <stdint.h>     //uint16_t
 #include <sys/socket.h> //socket(), AF_INET, SOCK_DGRAM
@@ -17,6 +19,8 @@
 #include <thread>       //thread
 #include <mqueue.h>     //POSIX Message Queues
 #include <errno.h>      //errno
+#include <sys/time.h>   //struct timeval
+#include <sys/select.h> //select()
 #include "../common/lib5grange/lib5grange.h"
 #include "../common/libMac5gRange/libMac5gRange.h"
 

--- a/build/src/coreL2/CoreTunInterface/TunInterface.cpp
+++ b/build/src/coreL2/CoreTunInterface/TunInterface.cpp
@@ -7,7 +7,7 @@
 @Arquive name : TunInterface.cpp
 @Classification : TUN Interface
 @
-@Last alteration : January 20th, 2020
+@Last alteration : July 2nd, 2020
 @Responsible : Eduardo Melao
 @Email : emelao@cpqd.com.br
 @Telephone extension : 7015
@@ -79,9 +79,6 @@ TunInterface::allocTunInterface(){
     ioctl(fileDescriptor, TUNSETIFF, (void *) &interfaceRequirement);
     strncpy(deviceName,interfaceRequirement.ifr_name, IFNAMSIZ);
 
-    //Set interface to be inblockable for reading
-    fcntl(fileDescriptor, F_SETFL, O_NONBLOCK);
-
     //Forces interface to me initialized as "UP" with MTU
     char cmd[100];
     sprintf(cmd, "ifconfig %s up mtu %s", interfaceRequirement.ifr_ifrn.ifrn_name, to_string(mtu).c_str());
@@ -93,9 +90,30 @@ TunInterface::allocTunInterface(){
 ssize_t 
 TunInterface::readTunInterface(
     char* buffer,           //Buffer to store packet read
-    size_t numberBytes)     //Number of bytes read
+    size_t numberBytes)     //Maximum number of bytes to read
 {
-    return read(fileDescriptor, buffer, numberBytes);
+    ssize_t ready;      //Variable to store return value from select() function
+
+    //Set timeout struct
+    struct timeval timeout; //Struct containing time to wait for data from Tun Interface
+    timeout.tv_sec = 0;
+    timeout.tv_usec = TUN_TIMEOUT_uSEC;
+
+
+    //Initialize file descriptor set
+    fd_set readFdSet;       //File descriptor set to pass as argument for select()
+    FD_ZERO(&readFdSet);
+    FD_SET(fileDescriptor, &readFdSet);
+
+    ready = select(fileDescriptor+1, &readFdSet, NULL, NULL, &timeout);
+
+    //If file descriptor is ready, return read function
+    if(ready>0)
+        return read(fileDescriptor, buffer, numberBytes);
+
+    //Else, for timeout return -1; For errors, print and return -1
+    if(ready<0) cout<<"[TunInterface] Errors occured reading from tun interface."<<endl;
+    return -1;
 }
 
 bool 

--- a/build/src/coreL2/CoreTunInterface/TunInterface.h
+++ b/build/src/coreL2/CoreTunInterface/TunInterface.h
@@ -15,6 +15,10 @@
 #include <sys/types.h>  //size_t
 #include <fcntl.h>      //open(), O_RDWR
 #include <sys/ioctl.h>  //ioctl()
+#include <sys/time.h>   //struct timeval
+#include <sys/select.h> //select()
+
+#define TUN_TIMEOUT_uSEC 4600    //TImeout, in microseconds, to wait for data from Tun interface (1 subframe duration)
 
 /**
  * @brief Class to alloc, save the descriptor and manage operations of TUN interface
@@ -43,7 +47,7 @@ public:
      * @param deviceName Interface name
      */
     TunInterface(const char* deviceName);
-   
+
     /**
      * @brief Creates interface
      * @param deviceName Interface name

--- a/build/src/coreL2/Cosora/Cosora.cpp
+++ b/build/src/coreL2/Cosora/Cosora.cpp
@@ -7,7 +7,7 @@
 @Arquive name : Cosora.cpp
 @Classification : Cosora
 @
-@Last alteration : March 31st, 2020
+@Last alteration : July 3rd, 2020
 @Responsible : Eduardo Melao
 @Email : emelao@cpqd.com.br
 @Telephone extension : 7015
@@ -55,12 +55,12 @@ Cosora::calculateSpectrumSensingValue(
     return spectrumSensingMeasurement;
 }
 
-uint16_t
+uint8_t
 Cosora::spectrumSensingConvertToRBIdle(
     uint8_t spectrumSensingReport)  //Spectrum Sensing Report calculated on UE
 {
     //#TODO: Implement Conversion of SS to RBIdle
-    uint16_t rbsIdle=0;
+    uint8_t rbsIdle=0;
     for(int i=0;i<4;i++)
         rbsIdle+=((spectrumSensingReport>>i)&1)*33;
     return rbsIdle;

--- a/build/src/coreL2/Cosora/Cosora.h
+++ b/build/src/coreL2/Cosora/Cosora.h
@@ -57,7 +57,7 @@ public:
      * @param spectrumSensingReport SS Report from UE
      * @returns Number of RBs in idle
      */
-    static uint16_t spectrumSensingConvertToRBIdle(uint8_t spectrumSensingReport);
+    static uint8_t spectrumSensingConvertToRBIdle(uint8_t spectrumSensingReport);
 
     /**
      * @brief This procedure waits for SSWaitTimeout subframes receiving SSR from UES and then

--- a/build/src/coreL2/L1L2Interface/L1L2Interface.cpp
+++ b/build/src/coreL2/L1L2Interface/L1L2Interface.cpp
@@ -7,7 +7,7 @@
 @Arquive name : L1L2Interface.cpp
 @Classification : L1 L2 Interface
 @
-@Last alteration : June 28th, 2020
+@Last alteration : July 3rd, 2020
 @Responsible : Eduardo Melao
 @Email : emelao@cpqd.com.br
 @Telephone extension : 7015
@@ -122,7 +122,26 @@ ssize_t
 L1L2Interface::receiveControlMessage(
     char* buffer)               //Buffer where message will be stored
 {
-    return mq_receive(l1l2InterfaceQueues.mqControlFromPhy, buffer, MQ_MAX_MSG_SIZE, NULL);
+    //Set timeout struct
+    struct timeval timeout; //Struct containing time to wait for data from Tun Interface
+    timeout.tv_sec = 0;
+    timeout.tv_usec = CONTROL_TIMEOUT_uSEC;
+
+
+    //Initialize file descriptor set
+    fd_set readFdSet;       //File descriptor set to pass as argument for select()
+    FD_ZERO(&readFdSet);
+    FD_SET(l1l2InterfaceQueues.mqControlFromPhy, &readFdSet);
+
+    size_t ready = select(l1l2InterfaceQueues.mqControlFromPhy+1, &readFdSet, NULL, NULL, &timeout);
+
+    //If file descriptor is ready, return read function
+    if(ready>0)
+        return mq_receive(l1l2InterfaceQueues.mqControlFromPhy, buffer, MQ_MAX_MSG_SIZE, NULL);
+
+    //Else, for timeout return -1; For errors, print and return -1
+    if(ready<0) cout<<"[L1L2Interface] Errors occured reading from Control MQ."<<endl;
+    return -1;
 }
 
 void 

--- a/build/src/coreL2/L1L2Interface/L1L2Interface.h
+++ b/build/src/coreL2/L1L2Interface/L1L2Interface.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDED_L1_L2_INTERFACE_H
 #define INCLUDED_L1_L2_INTERFACE_H
 
+#define CONTROL_TIMEOUT_uSEC 4600    //Timeout, in microseconds, to wait for control messages from PHY
+
 #include <iostream>
 #include <mqueue.h>         //Posix Message Queues
 #include <vector>
@@ -14,6 +16,8 @@
 #include <unistd.h>         //close()
 #include <errno.h>          //errno
 #include <boost/crc.hpp>    //Boost CRC library
+#include <sys/time.h>       //struct timeval
+#include <sys/select.h>     //select()
 #include "../../common/lib5grange/lib5grange.h"
 #include "../../common/libMac5gRange/libMac5gRange.h"
 

--- a/build/src/coreL2/MacController/MacController.cpp
+++ b/build/src/coreL2/MacController/MacController.cpp
@@ -7,7 +7,7 @@
 @Arquive name : MacController.cpp
 @Classification : MAC Controller
 @
-@Last alteration : June 19th, 2020
+@Last alteration : July 6th, 2020
 @Responsible : Eduardo Melao
 @Email : emelao@cpqd.com.br
 @Telephone extension : 7015
@@ -185,8 +185,8 @@ MacController::manager(){
                 //Set MAC mode to start mode
                 currentParameters->setMacMode(START_MODE);
 
-                //Wait for PHY to be ready for PHY_READY seconds
-                this_thread::sleep_for(chrono::seconds(PHY_READY));
+                //Wait for PHY to be ready for PHY_READY_TIMEOUT_SEC seconds
+                this_thread::sleep_for(chrono::seconds(PHY_READY_TIMEOUT_SEC));
             }
             break;
 
@@ -212,7 +212,7 @@ MacController::manager(){
                             protocolControl->sendInterlayerMessages(&stopRequestMessage, 1);
 
                             //Wait 1s for PHYConfig.Response Message
-                            this_thread::sleep_for(chrono::seconds(PHY_READY));
+                            this_thread::sleep_for(chrono::seconds(PHY_READY_TIMEOUT_SEC));
                         }
                     }
                 }
@@ -224,7 +224,7 @@ MacController::manager(){
                         protocolControl->sendInterlayerMessages(&stopRequestMessage, 1);
 
                         //Wait 1s for PHYConfig.Response Message
-                        this_thread::sleep_for(chrono::seconds(PHY_READY));
+                        this_thread::sleep_for(chrono::seconds(PHY_READY_TIMEOUT_SEC));
                     }
                 }
             }
@@ -314,6 +314,8 @@ MacController::manager(){
             }
             break;
         }
+        //Sleep before checking system state again
+        this_thread::sleep_for(chrono::microseconds(MAIN_THREAD_SLEEPING_TIME_uSEC));
     }
 }
 
@@ -474,10 +476,11 @@ MacController::decoding()
                 if(verbose) cout<<"\n\n[MacController] ___________ System entering RECONFIG mode by System parameters alteration. ___________\n"<<endl;
             }
         }
-        else{   //If it is BS, send report to BS
+        else{   //If it is UE, send report to BS
 
             protocolControl->rxMetrics->rankIndicator = bufferPdus[0]->rankIndicator_;
             protocolControl->rxMetrics->snr_avg = bufferPdus[0]->snr_avg_;
+            protocolControl->rxMetrics->numberRBs = bufferPdus[0]->allocation_.number_of_rb;
             protocolControl->rxMetricsReport(true);
         }
 

--- a/build/src/coreL2/MacController/MacController.h
+++ b/build/src/coreL2/MacController/MacController.h
@@ -29,7 +29,8 @@
 
 using namespace std;
 
-#define PHY_READY 1     //Timeout, in seconds, to wait for PHY to be stopped
+#define PHY_READY_TIMEOUT_SEC 1     //Timeout, in seconds, to wait for PHY to be stopped
+#define MAIN_THREAD_SLEEPING_TIME_uSEC 4600  //Time, in microseconds, to repeat manager() loop and check system state 
 
 //Initializing classes that will be defined in other .h files
 class ProtocolControl;

--- a/build/src/coreL2/Multiplexer/Multiplexer.cpp
+++ b/build/src/coreL2/Multiplexer/Multiplexer.cpp
@@ -7,7 +7,7 @@
 @Arquive name : Multiplexer.cpp
 @Classification : Multiplexer
 @
-@Last alteration : April 29th, 2020
+@Last alteration : July 6th, 2020
 @Responsible : Eduardo Melao
 @Email : emelao@cpqd.com.br
 @Telephone extension : 7015
@@ -115,7 +115,7 @@ Multiplexer::addSDU(
     //Verify if it is possible to insert SDU (considering CRC)
     if((size+2+currentPDUSize)>maxNumberBytes){
         if(verbose) cout<<"[Multiplexer] Tried to multiplex SDU which size extrapolates maxNumberBytes."<<endl;
-        exit(4);
+        return false;
     }
 
     //Adds SDU to position depending if it is Data or Control SDU

--- a/build/src/coreL2/Scheduler/Scheduler.cpp
+++ b/build/src/coreL2/Scheduler/Scheduler.cpp
@@ -7,7 +7,7 @@
 @Arquive name : Scheduler.cpp
 @Classification : Scheduler
 @
-@Last alteration : June 19th, 2020
+@Last alteration : July 6th, 2020
 @Responsible : Eduardo Melao
 @Email : emelao@cpqd.com.br
 @Telephone extension : 7015
@@ -58,8 +58,7 @@ Scheduler::scheduleRequestBS(
     rbsAllocation.resize(numberUEs);
 
     //Calculate total number of available RBs for next transmission
-    for(int i=0;i<4;i++)
-        numberAvailableRBs += (((currentParameters->getFLUTMatrix())>>i)&1)*33;
+    numberAvailableRBs = Cosora::spectrumSensingConvertToRBIdle(currentParameters->getFLUTMatrix());
 
     //For each UE, calculate desired number of RBs to allocate
     for(int i=0;i<numberUEs;i++){
@@ -101,7 +100,7 @@ Scheduler::scheduleRequestBS(
         currentChannel = rbOffset/33;       //Doing integer division will ignore fractional part
         //Then, verify if channel is available in Fusion lookup table. If it is not, search for next available channel
         if(rbOffset%33==0){
-            while(((currentParameters->getFLUTMatrix()>>currentChannel)&1)!=1){
+            while(((currentParameters->getFLUTMatrix()>>(3-currentChannel))&1)!=1){
                 currentChannel++;
                 rbOffset+=33;
             }
@@ -121,7 +120,7 @@ Scheduler::scheduleRequestBS(
 
             //Verify if next RB is idle
             if(rbOffset<132&&rbOffset%33==0){
-                if(((currentParameters->getFLUTMatrix()>>currentChannel)&1)!=1){
+                if(((currentParameters->getFLUTMatrix()>>(3-currentChannel))&1)!=1){
                     break;
                 }
             }
@@ -169,19 +168,26 @@ Scheduler::fillMacPdus(
     uint8_t destinationUeId;                //Current Destination UE Identification
     char sduBuffer[MQ_MAX_MSG_SIZE];        //Buffer to store SDU on aggregation procedure
     size_t sduSize;                         //SDU Size in bytes
-    for(int i=0;i<macPdus.size();i++){
-        destinationUeId = macPdus[i].allocation_.target_ue_id;
+    vector<MacPDU>::iterator pduIterator;   //Iterator for MacPDUs vector
+
+    //Set iterator to vector begin
+    pduIterator = macPdus.begin();          
+
+    //Iterate each PDU filling it
+    while(pduIterator != macPdus.end()){
+        //Get destination UeID for this PDU
+        destinationUeId = pduIterator->allocation_.target_ue_id;
 
         //Fill Numerology
-        macPdus[i].numID_ = currentParameters->getNumerology();
+        pduIterator->numID_ = currentParameters->getNumerology();
 
         //Fill MAC - PHY control struct
-        macPdus[i].macphy_ctl_.first_tb_in_subframe = i==0;
-        macPdus[i].macphy_ctl_.last_tb_in_subframe = i==(macPdus.size()-1);
-        macPdus[i].macphy_ctl_.sequence_number = i;
+        pduIterator->macphy_ctl_.first_tb_in_subframe = pduIterator==macPdus.begin();
+        pduIterator->macphy_ctl_.last_tb_in_subframe = pduIterator==(macPdus.end()-1);
+        pduIterator->macphy_ctl_.sequence_number = pduIterator - macPdus.begin();
 
         //Fill MIMO struct
-        macPdus[i].mimo_ = currentParameters->getMimo(destinationUeId);
+        pduIterator->mimo_ = currentParameters->getMimo(destinationUeId);
 
         //Fill MCS struct
         uint8_t mcsValue;   //Value of MCS for current transmission and current destination
@@ -190,14 +196,14 @@ Scheduler::fillMacPdus(
         }
         else{
             mcsValue = currentParameters->getMcsUplink(destinationUeId);
-            macPdus[i].mcs_.power_offset=currentParameters->getTPC(destinationUeId);
+            pduIterator->mcs_.power_offset=currentParameters->getTPC(destinationUeId);
         }
-        macPdus[i].mcs_.modulation = mcsToModulation[mcsValue];
-        macPdus[i].mcs_.num_coded_bytes = get_bit_capacity(macPdus[i]);
+        pduIterator->mcs_.modulation = mcsToModulation[mcsValue];
+        pduIterator->mcs_.num_coded_bytes = get_bit_capacity(*pduIterator)/8;
 
         //Calculate number of bits for next transmission
-        size_t numberBytes = get_net_byte_capacity(macPdus[i].numID_, macPdus[i].allocation_, macPdus[i].mimo_, macPdus[i].mcs_.modulation, mcsToCodeRate[mcsValue]);
-        if(verbose) cout<<"[Scheduler] Scheduled "<<numberBytes<<" Bytes for PDU "<<i<<endl;
+        size_t numberBytes = get_net_byte_capacity(pduIterator->numID_, pduIterator->allocation_, pduIterator->mimo_, pduIterator->mcs_.modulation, mcsToCodeRate[mcsValue]);
+        if(verbose) cout<<"[Scheduler] Scheduled "<<numberBytes<<" Bytes for PDU "<<(int)pduIterator->macphy_ctl_.sequence_number<<" destinated to UE "<<(int)pduIterator->allocation_.target_ue_id<<endl;
 
         //Create a new Multiplexer object to aggregate SDUs
         Multiplexer* multiplexer = new Multiplexer(numberBytes, currentParameters->getCurrentMacAddress(), destinationUeId, verbose);
@@ -242,6 +248,9 @@ Scheduler::fillMacPdus(
             exit(1);
         }
         
+        //Lock Data Queue modifications semaphore
+        sduBuffers->lockDataSduQueue();
+        
         for(int j=0;j<numberDataSDUs;j++){
             //Verify if it is possivel to enqueue next SDU
             if((multiplexer->getNumberofBytes() + 2 + sduBuffers->getNextDataSduSize(destinationUeId))>numberBytes){
@@ -266,109 +275,20 @@ Scheduler::fillMacPdus(
             //Add SDU to multiplexer
             multiplexer->addSDU(sduBuffer, sduSize, 1);
         }
+        //Release Data Queue modifications semaphore
+        sduBuffers->unlockDataSduQueue();
 
         //Retreive full PDU from multiplexer if not empty
         if(!multiplexer->isEmpty()){
-            multiplexer->getPDU(macPdus[i].mac_data_);
-            macPdus[i].mcs_.num_info_bytes = macPdus[i].mac_data_.size();
+            multiplexer->getPDU(pduIterator->mac_data_);
+            pduIterator->mcs_.num_info_bytes = pduIterator->mac_data_.size();
+            //Avance PDU iterator
+            pduIterator++;
         }
         else
-            macPdus.erase(macPdus.begin()+i);
+            macPdus.erase(pduIterator);
         
         //Delete multiplexer
         delete multiplexer;
-    }
-}
-
-void
-Scheduler::calculateDownlinkSpectrumAllocation(
-    MacPDU** macPdus,           //Array of MAC PDUs where scheduler will store Multiplexed SDUs
-    uint8_t fusionLutValue)     //Fusion Lookup Table value: array of 4 least significat bits
-{
-    //Process cases 
-    switch(fusionLutValue){
-        case 15:    //1111 -> 2x33 RBs for both UEs
-            //UE[0]: RBs 0 to 65
-            macPdus[0]->allocation_.first_rb = 0;
-            macPdus[0]->allocation_.number_of_rb = 66;
-
-            //UE[1]: RBs 66 to 131
-            macPdus[1]->allocation_.first_rb = 66;
-            macPdus[1]->allocation_.number_of_rb = 66;
-        break;
-
-        case 13: case 11:   //1101(13) or 1011(11) -> 2x33 RBs for one UE and 1x33 RBs for the other
-            //UE[0]: RBs 0 to 32(flut=11) or 65(flut=13)
-            //UE[1]: RBs 66(flut=11) or 99(flut=13) to 131
-
-            macPdus[0]->allocation_.first_rb = 0;
-
-            if(fusionLutValue==11){
-                macPdus[0]->allocation_.number_of_rb = 33;
-                macPdus[1]->allocation_.first_rb = 66;
-                macPdus[1]->allocation_.number_of_rb = 66;
-            }
-            else{
-                macPdus[0]->allocation_.number_of_rb = 66;
-                macPdus[1]->allocation_.first_rb = 99;
-                macPdus[1]->allocation_.number_of_rb = 33;
-            }
-        break;
-
-        case 14: case 7:    //1110(14) or 0111(7) -> 1,5x33 RBs for both UEs
-            //UE[0]: RBs 0 to 48(flut=14) or 33 to 81(flut=7)
-            //UE[1]: RBs 49 to 98(flut=14) or 82 to 131(flut=7)
-
-            if(fusionLutValue==7){
-                macPdus[0]->allocation_.first_rb = 33;
-                macPdus[1]->allocation_.first_rb = 82;
-            }
-            else{
-                macPdus[0]->allocation_.first_rb = 0;
-                macPdus[1]->allocation_.first_rb = 49;
-            }
-
-            macPdus[0]->allocation_.number_of_rb = 49;
-            macPdus[1]->allocation_.number_of_rb = 50;
-        break;
-
-        case 9: case 10: case 12: case 5: case 6: case 3:           //1001, 1010, 1100, 0101, 0110 or 0011 -> 1x33 RBs for both UEs
-            //UE[0]: RBs 0 to 32(flut=9,10,12) or 33 to 65(flut=5,6) or 66 to 98(flut=3)
-            //UE[1]: RBs 33 to 65(flut=12) or 66 to 98(flut=6,10) or 99 to 131(flut=9,5,3)
-            for(int i=0;i<3;i++){
-                if((fusionLutValue<<i)&8==8){
-                    macPdus[0]->allocation_.first_rb = i*33;
-                    break;
-                }
-            }
-            for(int i=0;i<3;i++){
-                if((fusionLutValue>>i)&1==1){
-                    macPdus[1]->allocation_.first_rb = (3-i)*33;
-                    break;
-                }
-            }
-            macPdus[0]->allocation_.number_of_rb = 33;
-            macPdus[1]->allocation_.number_of_rb = 33;
-        break;
-
-        case 8: case 4: case 2: case 1:     //1000, 0100, 0010 or 0001 -> 0,5x33 RBs for both UEs
-            //UE[0]: RBs 0 to 15(flut=8) or 33 to 48(flut=4) or 66 to 81(flut=2) ir 99 to 114(flut=1)
-            //UE[1]: RBs 16 to 32(flut=8) or 49 to 65(flut=4) or 82 to 98(flut=2) ir 115 to 131(flut=1)
-            
-            for(int i=0;i<4;i++){
-                if((fusionLutValue<<i)&8==8){
-                    macPdus[0]->allocation_.first_rb = 33*i;
-                    break;
-                }
-            }
-            macPdus[1]->allocation_.first_rb = macPdus[0]->allocation_.number_of_rb + 16;
-
-            macPdus[0]->allocation_.number_of_rb = 16;
-            macPdus[1]->allocation_.number_of_rb = 17;
-        break;
-
-        default:
-            if(verbose) cout<<"[Scheduler] Invalid Fusion Lookup Table value"<<endl;
-        break;
     }
 }

--- a/build/src/coreL2/Scheduler/Scheduler.h
+++ b/build/src/coreL2/Scheduler/Scheduler.h
@@ -59,13 +59,6 @@ public:
      * @param macPdus Vector of MacPDUs to be filled
      */
     void fillMacPdus(vector<MacPDU> &macPdus);
-
-    /**
-     * @brief Procedure thar calculates spectrum allocation for 2 UEs (and only) for schedulingRequest procedure for downlink
-     * @param macPDUs Array of MAC PDUs where scheduler will store Multiplexed SDUs
-     * @param fusionLutValue Fusion Lookup Table value: array of 4 least significat bits
-     */
-    void calculateDownlinkSpectrumAllocation(MacPDU** macPdus, uint8_t fusionLutValue);
 };
 
 #endif //INCLUDED_SCHEDULER_H

--- a/build/src/coreL2/SduBuffers/SduBuffers.h
+++ b/build/src/coreL2/SduBuffers/SduBuffers.h
@@ -141,5 +141,16 @@ public:
      * @brief Checks for IP packets with timeout exceeded
      */
     void dataSduTimeoutChecking();
+
+    /**
+     * @brief Locks mutex for Data SDU queue
+     */
+    void lockDataSduQueue();
+    
+    /**
+     * @brief Locks mutex for Data SDU queue
+     */
+    void unlockDataSduQueue();
+    
 };
 #endif  //SDU_BUFFERS_H

--- a/build/src/coreL2/SystemParameters/DynamicParameters.h
+++ b/build/src/coreL2/SystemParameters/DynamicParameters.h
@@ -26,7 +26,7 @@ class DynamicParameters{
 private:
 protected:
     //Dynamic information as informed on spreadsheet L1-L2_InterfaceDefinition.xlsx
-	uint8_t fLutMatrix;							//[4 bits] BitMap from Fusion Spectrum Analysis
+	uint8_t fLutMatrix;							//[4 bits] BitMap [0 0 0 0 CH0 CH1 CH2 CH3] from Fusion Spectrum Analysis
 	vector<allocation_cfg_t> ulReservation;	    //[24 bits each] Spectrum allocation for Uplink
 	vector<uint8_t> mcsDownlink;				//[4 bit each] Modulation and Coding Scheme for Downlink
 	vector<uint8_t> mcsUplink;					//[4 bit each] Modulation and Coding Scheme for Uplink


### PR DESCRIPTION
* Number of info bytes corrected
This field was implemented to express bits but it is expected to contain number of Bytes

* Corrected IP timeout strategy; Fixed PDUs deletion
Wrong MacPDU deletion was causing inconsistencies on PHY.

* Changed order of Fusion decoding:
The order is [0 ... 0 0 0 CH0 CH1 CH2 CH3]

* Changed order of Fusion decoding:
The order is [0 ... 0 0 0 CH0 CH1 CH2 CH3]

* Changed types of size vars: uint16 to size_t

* Implemented select() on tun interface
This implementation removes full CPU usage from Tun thread.

* Implemented select() for Interlayer messages
This implementation removes full CPU usage from receiving interlayer messages thread.

* Reduced CPU usage from manager() thread

* Added numberPDUs on UESubframeRx.Start
Also changedd type of spectrum sensing variables back to int

* Bugfixes on RxMetrics message

* Fixed RxMetrics arrors and Added numRBs parameter
NumberRBs is necessary to let MAC know how many RBs were considered calculating average SNR

* Changed size of SDUs back to uint16_t
This was changed back because MAC header only supports SDUs with size up to 2^15 bits